### PR TITLE
Refactor main page layout into command-center UX

### DIFF
--- a/components/AnalysisTile.tsx
+++ b/components/AnalysisTile.tsx
@@ -13,6 +13,7 @@ import { createPortal } from 'react-dom';
 interface AnalysisTileProps {
   findings: Finding[];
   onSelectRequest: (id: string) => void;
+  embedded?: boolean;
 }
 
 /* ======================
@@ -47,6 +48,7 @@ function cleanMessage(description: string, url: string) {
 export default function AnalysisTile({
   findings,
   onSelectRequest,
+  embedded = false,
 }: AnalysisTileProps) {
   const [expandedTypes, setExpandedTypes] = useState<Record<string, boolean>>({});
   const [expandedUrls, setExpandedUrls] = useState<Record<string, boolean>>({});
@@ -81,7 +83,11 @@ export default function AnalysisTile({
 
   if (findings.length === 0) {
     return (
-      <div className="border border-gray-200 rounded-xl p-4 bg-white flex items-center gap-2">
+      <div
+        className={`${
+          embedded ? 'p-0 bg-transparent border-0' : 'border border-gray-200 rounded-xl p-4 bg-white'
+        } flex items-center gap-2`}
+      >
         <CheckCircleIcon className="h-5 w-5 text-emerald-500" />
         <div className="text-sm text-gray-700">
           No issues detected in this analysis.
@@ -91,7 +97,11 @@ export default function AnalysisTile({
   }
 
   return (
-    <div className="border border-gray-200 rounded-xl p-4 bg-white space-y-4">
+    <div
+      className={`${
+        embedded ? 'p-0 bg-transparent border-0' : 'border border-gray-200 rounded-xl p-4 bg-white'
+      } space-y-4`}
+    >
       {/* Header */}
       <div className="flex items-center gap-2">
         <ExclamationTriangleIcon className="h-5 w-5 text-amber-500" />

--- a/components/FiltersPanel.tsx
+++ b/components/FiltersPanel.tsx
@@ -1,0 +1,247 @@
+'use client';
+
+import {
+  ChevronDownIcon,
+  CheckIcon,
+  MagnifyingGlassIcon,
+} from '@heroicons/react/20/solid';
+import { useEffect, useRef, useState } from 'react';
+import { getMethodStyle, getStatusStyle, getStatusText } from '@/lib/utils/filterStyles';
+
+type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+type StatusClass = '2xx' | '3xx' | '4xx' | '5xx';
+
+interface FiltersPanelProps {
+  selectedMethods: Set<HttpMethod>;
+  setSelectedMethods: (next: Set<HttpMethod>) => void;
+  selectedStatusClasses: Set<StatusClass>;
+  setSelectedStatusClasses: (next: Set<StatusClass>) => void;
+  urlQuery: string;
+  setUrlQuery: (next: string) => void;
+}
+
+export default function FiltersPanel({
+  selectedMethods,
+  setSelectedMethods,
+  selectedStatusClasses,
+  setSelectedStatusClasses,
+  urlQuery,
+  setUrlQuery,
+}: FiltersPanelProps) {
+  const [openDropdown, setOpenDropdown] = useState<'method' | 'status' | null>(
+    null
+  );
+  const dropdownRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (!dropdownRef.current?.contains(e.target as Node)) {
+        setOpenDropdown(null);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, []);
+
+  const toggleSetValue = <T,>(set: Set<T>, value: T) => {
+    const next = new Set(set);
+    next.has(value) ? next.delete(value) : next.add(value);
+    return next;
+  };
+
+  return (
+    <div className="border border-gray-200 rounded-xl p-4 bg-white" ref={dropdownRef}>
+      <div className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+        Filters
+      </div>
+      <div className="mt-3 space-y-3 text-sm">
+        <div className="relative">
+          <MagnifyingGlassIcon className="h-4 w-4 absolute left-2 top-1/2 -translate-y-1/2 text-gray-400" />
+          <input
+            value={urlQuery}
+            onChange={(e) => setUrlQuery(e.target.value)}
+            placeholder="Filter URL"
+            className="pl-8 pr-2 py-1.5 w-full border border-gray-200 rounded-md"
+          />
+        </div>
+
+        <div className="flex items-center gap-2">
+          <Dropdown
+            label="Method"
+            isOpen={openDropdown === 'method'}
+            onToggle={() =>
+              setOpenDropdown(openDropdown === 'method' ? null : 'method')
+            }
+          >
+            {(['GET', 'POST', 'PUT', 'PATCH', 'DELETE'] as HttpMethod[]).map(
+              (m) => (
+                <DropdownOption
+                  key={m}
+                  active={selectedMethods.has(m)}
+                  variant="method"
+                  value={m}
+                  onClick={() =>
+                    setSelectedMethods(toggleSetValue(selectedMethods, m))
+                  }
+                >
+                  {m}
+                </DropdownOption>
+              )
+            )}
+          </Dropdown>
+
+          <Dropdown
+            label="Status"
+            isOpen={openDropdown === 'status'}
+            onToggle={() =>
+              setOpenDropdown(openDropdown === 'status' ? null : 'status')
+            }
+          >
+            {(['2xx', '3xx', '4xx', '5xx'] as StatusClass[]).map((s) => (
+              <DropdownOption
+                key={s}
+                active={selectedStatusClasses.has(s)}
+                variant="status"
+                value={s}
+                onClick={() =>
+                  setSelectedStatusClasses(toggleSetValue(selectedStatusClasses, s))
+                }
+              >
+                {s}
+              </DropdownOption>
+            ))}
+          </Dropdown>
+        </div>
+        {(selectedMethods.size > 0 ||
+          selectedStatusClasses.size > 0 ||
+          urlQuery.trim() !== '') && (
+          <div className="flex flex-wrap gap-2 pt-2">
+            {Array.from(selectedMethods).map((m) => (
+              <FilterChip
+                key={`method:${m}`}
+                label={m}
+                variant="method"
+                value={m}
+                onRemove={() => {
+                  const next = new Set(selectedMethods);
+                  next.delete(m);
+                  setSelectedMethods(next);
+                }}
+              />
+            ))}
+            {Array.from(selectedStatusClasses).map((s) => (
+              <FilterChip
+                key={`status:${s}`}
+                label={s}
+                variant="status"
+                value={s}
+                onRemove={() => {
+                  const next = new Set(selectedStatusClasses);
+                  next.delete(s);
+                  setSelectedStatusClasses(next);
+                }}
+              />
+            ))}
+            {urlQuery.trim() !== '' && (
+              <FilterChip
+                key="url"
+                label={`URL: ${urlQuery}`}
+                variant="url"
+                onRemove={() => setUrlQuery('')}
+              />
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function Dropdown({
+  label,
+  isOpen,
+  onToggle,
+  children,
+}: {
+  label: string;
+  isOpen: boolean;
+  onToggle: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="relative">
+      <button
+        onClick={onToggle}
+        aria-expanded={isOpen}
+        className="flex items-center gap-1 px-3 py-1.5 border border-gray-200 rounded-md hover:text-gray-900 text-xs"
+      >
+        {label}
+        <ChevronDownIcon className="h-4 w-4" />
+      </button>
+
+      {isOpen && (
+        <div className="absolute z-10 mt-1 w-36 bg-white border border-gray-200 rounded-md">
+          {children}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function DropdownOption({
+  children,
+  active,
+  variant,
+  value,
+  onClick,
+}: {
+  children: React.ReactNode;
+  active: boolean;
+  variant: 'method' | 'status';
+  value: string;
+  onClick: () => void;
+}) {
+  const activeStyle =
+    variant === 'method'
+      ? getMethodStyle(value).text
+      : getStatusText(value);
+  return (
+    <div
+      onClick={onClick}
+      className="flex items-center justify-between px-3 py-2 cursor-pointer hover:bg-gray-50 text-sm"
+    >
+      <span className={active ? activeStyle : ''}>{children}</span>
+      {active && <CheckIcon className="h-4 w-4" />}
+    </div>
+  );
+}
+
+function FilterChip({
+  label,
+  variant,
+  value,
+  onRemove,
+}: {
+  label: string;
+  variant: 'method' | 'status' | 'url';
+  value?: string;
+  onRemove: () => void;
+}) {
+  const styles =
+    variant === 'method'
+      ? getMethodStyle(value ?? '')
+      : variant === 'status'
+      ? getStatusStyle(value ?? '')
+      : { border: 'border-emerald-200', bg: 'bg-emerald-50', text: 'text-emerald-700' };
+
+  return (
+    <div
+      className={`flex items-center gap-1 rounded-full border px-2 py-1 text-xs ${styles.border} ${styles.bg} ${styles.text}`}
+    >
+      <span className="truncate max-w-[150px] font-semibold">{label}</span>
+      <button onClick={onRemove} className="text-current/70 hover:text-current">
+        ×
+      </button>
+    </div>
+  );
+}

--- a/components/RequestDetailsPanel.tsx
+++ b/components/RequestDetailsPanel.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Finding, HarRequest, HarTimings } from '@/types';
+import { getMethodStyle, getStatusText } from '@/lib/utils/filterStyles';
 import {
   ArrowDownTrayIcon,
   BeakerIcon,
@@ -90,8 +91,20 @@ export default function RequestDetailsPanel({
 function OverviewTab({ request }: { request: HarRequest }) {
   return (
     <Section title="Request summary">
-      <KeyValue label="Method" value={request.method} />
-      <KeyValue label="Status" value={request.status} />
+      <KeyValue
+        label="Method"
+        value={request.method}
+        className={getMethodStyle(request.method).text}
+      />
+      <KeyValue
+        label="Status"
+        value={request.status}
+        className={
+          request.status < 200
+            ? 'text-gray-900'
+            : getStatusText(statusToClass(request.status))
+        }
+      />
       <KeyValue label="Domain" value={request.domain ?? '—'} />
       <KeyValue label="Path" value={request.path ?? '—'} wrap />
       <KeyValue label="Duration" value={`${Math.round(request.duration)} ms`} />
@@ -109,7 +122,11 @@ function RequestTab({ request }: { request: HarRequest }) {
   return (
     <>
       <Section title="Request">
-        <KeyValue label="Method" value={request.method} />
+        <KeyValue
+          label="Method"
+          value={request.method}
+          className={getMethodStyle(request.method).text}
+        />
         <KeyValue label="Path" value={request.path ?? '—'} wrap />
       </Section>
 
@@ -138,7 +155,15 @@ function ResponseTab({ request }: { request: HarRequest }) {
   return (
     <>
       <Section title="Response">
-        <KeyValue label="Status" value={`${request.status} ${request.statusText ?? ''}`} />
+        <KeyValue
+          label="Status"
+          value={`${request.status} ${request.statusText ?? ''}`}
+          className={
+            request.status < 200
+              ? 'text-gray-900'
+              : getStatusText(statusToClass(request.status))
+          }
+        />
         <KeyValue label="From cache" value={request.fromCache ? 'Yes' : 'No'} />
         <KeyValue label="Server IP" value={request.serverIp ?? '—'} />
       </Section>
@@ -361,16 +386,22 @@ function KeyValue({
   value,
   wrap,
   mono,
+  className,
 }: {
   label: string;
   value: string | number;
   wrap?: boolean;
   mono?: boolean;
+  className?: string;
 }) {
   return (
     <div className="flex flex-col gap-0.5">
       <div className="text-xs text-gray-500">{label}</div>
-      <div className={`text-sm text-gray-900 ${wrap ? 'break-all' : ''} ${mono ? 'font-mono' : ''}`}>
+      <div
+        className={`text-sm text-gray-900 ${wrap ? 'break-all' : ''} ${
+          mono ? 'font-mono' : ''
+        } ${className ?? ''}`}
+      >
         {value}
       </div>
     </div>
@@ -443,6 +474,13 @@ function normalizeTimings(timings?: HarTimings) {
       value: value != null && value >= 0 ? Math.round(value) : 0,
     }))
     .filter((t) => t.value > 0);
+}
+
+function statusToClass(status: number) {
+  if (status >= 500) return '5xx';
+  if (status >= 400) return '4xx';
+  if (status >= 300) return '3xx';
+  return '2xx';
 }
 
 function formatBytes(bytes?: number) {

--- a/lib/utils/filterStyles.ts
+++ b/lib/utils/filterStyles.ts
@@ -1,0 +1,46 @@
+export function getMethodStyle(method: string) {
+  switch (method.toUpperCase()) {
+    case 'GET':
+      return { border: 'border-emerald-200', bg: 'bg-emerald-50', text: 'text-emerald-700' };
+    case 'POST':
+      return { border: 'border-blue-200', bg: 'bg-blue-50', text: 'text-blue-700' };
+    case 'PUT':
+      return { border: 'border-violet-200', bg: 'bg-violet-50', text: 'text-violet-700' };
+    case 'PATCH':
+      return { border: 'border-amber-200', bg: 'bg-amber-50', text: 'text-amber-700' };
+    case 'DELETE':
+      return { border: 'border-red-200', bg: 'bg-red-50', text: 'text-red-700' };
+    default:
+      return { border: 'border-slate-200', bg: 'bg-slate-50', text: 'text-slate-700' };
+  }
+}
+
+export function getStatusStyle(status: string) {
+  switch (status) {
+    case '2xx':
+      return { border: 'border-emerald-600', bg: 'bg-emerald-600', text: 'text-white' };
+    case '3xx':
+      return { border: 'border-blue-600', bg: 'bg-blue-600', text: 'text-white' };
+    case '4xx':
+      return { border: 'border-amber-600', bg: 'bg-amber-600', text: 'text-white' };
+    case '5xx':
+      return { border: 'border-red-600', bg: 'bg-red-600', text: 'text-white' };
+    default:
+      return { border: 'border-slate-600', bg: 'bg-slate-600', text: 'text-white' };
+  }
+}
+
+export function getStatusText(status: string) {
+  switch (status) {
+    case '2xx':
+      return 'text-emerald-700';
+    case '3xx':
+      return 'text-blue-700';
+    case '4xx':
+      return 'text-amber-700';
+    case '5xx':
+      return 'text-red-700';
+    default:
+      return 'text-gray-900';
+  }
+}


### PR DESCRIPTION
**Summary**
- Refactored the main layout into a 3‑column command‑center view.
- Moved filters into the left rail and added filter chips with semantic colors.
- Added findings summary in the left rail and a findings view that replaces the table.
- Reworked metrics into clickable pills for issue filtering.
- Standardized status/method color usage across table and details.

**Changes**
- `app/page.tsx`: new layout, findings view mode, issue filter pills, left rail updates.
- `components/FiltersPanel.tsx`: filter chips + category coloring, dropdown wiring.
- `components/ResultsTable.tsx`: issue filter support, shared color usage.
- `components/RequestDetailsPanel.tsx`: shared method/status colors.
- `lib/utils/filterStyles.ts`: centralized color helpers.

**Testing**
- Not run (UI-only changes).

**Notes**
- Findings view now replaces the table; can iterate on this UX later.
