### PR TITLE
Refine dark theme contrast and hide component scrollbars

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,8 +1,15 @@
 @import "tailwindcss";
 
+@custom-variant dark (&:where(.dark, .dark *));
+
 :root {
   --background: #ffffff;
-  --foreground: #171717;
+  --foreground: #151a26;
+}
+
+.dark {
+  --background: #0f0f0f;
+  --foreground: #e5e5e5;
 }
 
 @theme inline {
@@ -10,13 +17,6 @@
   --color-foreground: var(--foreground);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
 }
 
 body {
@@ -33,4 +33,13 @@ pre {
 .font-method {
   font-family: var(--font-fira-code);
   font-variant-ligatures: none;
+}
+
+.no-scrollbar {
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+.no-scrollbar::-webkit-scrollbar {
+  display: none;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -30,7 +30,7 @@ export default function RootLayout({
     <html lang="en" className="h-full">
       <body
         // Apply font variables and common light‑mode styling here
-        className={`${geistSans.variable} ${geistMono.variable} ${firaCode.variable} antialiased bg-gray-50 text-gray-900`}
+        className={`${geistSans.variable} ${geistMono.variable} ${firaCode.variable} antialiased`}
       >
         {children}
       </body>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -29,13 +29,18 @@ import {
   ArrowDownTrayIcon,
   Cog6ToothIcon,
   TrashIcon,
+  MoonIcon,
+  SunIcon,
 } from '@heroicons/react/24/outline';
 
 type AnalysisMode = 'network' | 'token';
+type ThemePreference = 'system' | 'light' | 'dark';
 
 export default function HomePage() {
   const [analysisStarted, setAnalysisStarted] = useState(false);
   const [mode, setMode] = useState<AnalysisMode>('network');
+  const [theme, setTheme] = useState<ThemePreference>('system');
+  const [isDarkMode, setIsDarkMode] = useState(false);
   const [guideTab, setGuideTab] = useState<'chrome' | 'edge' | 'firefox' | 'safari'>('chrome');
   const [requests, setRequests] = useState<HarRequest[]>([]);
   const [tokenInfo, setTokenInfo] = useState<TokenInfo | null>(null);
@@ -119,33 +124,86 @@ export default function HomePage() {
     }
   }, [analysisStarted]);
 
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const stored = window.localStorage.getItem('theme');
+    if (stored === 'light' || stored === 'dark' || stored === 'system') {
+      setTheme(stored);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const root = document.documentElement;
+    const media = window.matchMedia('(prefers-color-scheme: dark)');
+
+    const applyTheme = (pref: ThemePreference) => {
+      const shouldDark = pref === 'dark' || (pref === 'system' && media.matches);
+      root.classList.toggle('dark', shouldDark);
+      setIsDarkMode(shouldDark);
+    };
+
+    applyTheme(theme);
+    window.localStorage.setItem('theme', theme);
+
+    const handler = (event: MediaQueryListEvent) => {
+      if (theme === 'system') {
+        root.classList.toggle('dark', event.matches);
+        setIsDarkMode(event.matches);
+      }
+    };
+
+    media.addEventListener('change', handler);
+    return () => media.removeEventListener('change', handler);
+  }, [theme]);
+
+  const handleThemeToggle = () => {
+    setTheme(isDarkMode ? 'light' : 'dark');
+  };
+
   return (
     <div
       className={`flex flex-col ${
         analysisStarted ? 'h-screen' : 'min-h-screen'
       }`}
     >
-      <header className="w-full border-b border-gray-200">
+      <header className="w-full border-b border-gray-200 dark:border-neutral-800">
         <div className="max-w-[90rem] mx-auto px-4 sm:px-6 lg:px-8 py-4 flex items-center justify-between">
           <Link href="/" className="flex items-center gap-3">
-            <Square3Stack3DIcon className="h-6 w-6 text-gray-900" />
+            <Square3Stack3DIcon className="h-6 w-6 text-gray-900 dark:text-neutral-100" />
             <div>
-              <div className="text-lg font-semibold">Replin Inspect</div>
-              <div className="text-xs text-gray-500">
+              <div className="text-lg font-semibold text-gray-900 dark:text-neutral-100">Replin Inspect</div>
+              <div className="text-xs text-gray-500 dark:text-neutral-400">
                 Client-side troubleshooting tools
               </div>
             </div>
           </Link>
 
-          <a
-            href="https://github.com/pillowbytes/replin-inspect/issues"
-            className="flex items-center gap-2 text-sm px-3 py-1.5 border border-gray-300 rounded-md hover:bg-gray-50"
-            target="_blank"
-            rel="noreferrer"
-          >
-            <BugAntIcon className="h-4 w-4" />
-            Report issue
-          </a>
+          <div className="flex items-center gap-2">
+            <Tooltip label={isDarkMode ? 'Switch to light mode' : 'Switch to dark mode'}>
+              <button
+                onClick={handleThemeToggle}
+                className="flex items-center gap-2 text-sm px-3 py-1.5 border border-gray-300 dark:border-neutral-700 rounded-md text-gray-700 dark:text-neutral-200 hover:bg-gray-50 dark:hover:bg-neutral-800"
+                type="button"
+              >
+                {isDarkMode ? (
+                  <SunIcon className="h-4 w-4" />
+                ) : (
+                  <MoonIcon className="h-4 w-4" />
+                )}
+                Theme
+              </button>
+            </Tooltip>
+            <a
+              href="https://github.com/pillowbytes/replin-inspect/issues"
+              className="flex items-center gap-2 text-sm px-3 py-1.5 border border-gray-300 dark:border-neutral-700 rounded-md hover:bg-gray-50 dark:hover:bg-neutral-800"
+              target="_blank"
+              rel="noreferrer"
+            >
+              <BugAntIcon className="h-4 w-4" />
+              Report issue
+            </a>
+          </div>
         </div>
       </header>
 
@@ -154,15 +212,15 @@ export default function HomePage() {
           analysisStarted ? 'overflow-hidden flex flex-col gap-6' : 'space-y-8'
         }`}
       >
-        <nav className="relative border-b border-gray-200 pb-0 mb-6">
+        <nav className="relative border-b border-gray-200 dark:border-neutral-800 pb-0 mb-6">
           <div className="flex items-center justify-center">
-            <div className="inline-flex rounded-t-lg rounded-b-none bg-gray-100 p-1 text-sm">
+            <div className="inline-flex rounded-t-lg rounded-b-none bg-gray-100 dark:bg-neutral-900 p-1 text-sm">
               <button
                 onClick={() => setMode('network')}
                 className={`px-3 py-1.5 rounded-md ${
                   mode === 'network'
-                    ? 'bg-white border border-gray-200'
-                    : 'text-gray-600'
+                    ? 'bg-white dark:bg-neutral-800 border border-gray-200 dark:border-neutral-700 text-gray-900 dark:text-neutral-100'
+                    : 'text-gray-600 dark:text-neutral-300'
                 }`}
               >
                 <GlobeAltIcon className="h-4 w-4 inline mr-1" />
@@ -173,7 +231,7 @@ export default function HomePage() {
                   onClick={() => setMode('token')}
                   disabled
                   aria-disabled="true"
-                  className="px-3 py-1.5 rounded-md text-gray-400 cursor-not-allowed"
+                  className="px-3 py-1.5 rounded-md text-gray-400 dark:text-neutral-500 cursor-not-allowed"
                 >
                   <KeyIcon className="h-4 w-4 inline mr-1" />
                   Token
@@ -185,7 +243,7 @@ export default function HomePage() {
           {analysisStarted && (
             <button
               onClick={handleNewAnalysis}
-              className="absolute left-0 top-0 flex items-center gap-2 text-sm font-semibold px-3 py-1.5 border border-gray-300 rounded-md hover:bg-gray-50"
+              className="absolute left-0 top-0 flex items-center gap-2 text-sm font-semibold px-3 py-1.5 border border-gray-300 dark:border-neutral-700 rounded-md hover:bg-gray-50 dark:hover:bg-neutral-800"
             >
               <FolderPlusIcon className="h-4 w-4" />
               New analysis
@@ -195,18 +253,18 @@ export default function HomePage() {
 
         {!analysisStarted ? (
           <div className="space-y-6">
-            <div className="border border-gray-200 rounded-2xl p-8 bg-white">
+            <div className="border border-gray-200 dark:border-neutral-800 rounded-2xl p-8 bg-white dark:bg-neutral-900">
               <div className="grid grid-cols-1 lg:grid-cols-[1.4fr_1fr] gap-6 items-center">
                 <div className="space-y-3">
-                  <div className="text-xl font-semibold text-gray-900">
+                  <div className="text-xl font-semibold text-gray-900 dark:text-neutral-100">
                     Start inspecting a HAR file
                   </div>
-                  <p className="text-sm text-gray-600">
+                  <p className="text-sm text-gray-600 dark:text-neutral-300">
                     Client-side request diagnostics for support and troubleshooting.
                   </p>
-                  <div className="pt-4 space-y-3 text-xs text-gray-500">
-                    <div className="flex items-center gap-2 text-xs font-semibold text-gray-900">
-                      <ShieldCheckIcon className="h-4 w-4 text-gray-500" />
+                  <div className="pt-4 space-y-3 text-xs text-gray-500 dark:text-neutral-400">
+                    <div className="flex items-center gap-2 text-xs font-semibold text-gray-900 dark:text-neutral-100">
+                      <ShieldCheckIcon className="h-4 w-4 text-gray-500 dark:text-neutral-400" />
                       Privacy
                     </div>
                     <p>
@@ -214,14 +272,14 @@ export default function HomePage() {
                       never uploaded or stored.
                     </p>
                     <div className="pt-3 space-y-2">
-                      <div className="flex items-center gap-2 text-xs font-semibold text-gray-900">
-                        <CircleStackIcon className="h-4 w-4 text-gray-500" />
+                      <div className="flex items-center gap-2 text-xs font-semibold text-gray-900 dark:text-neutral-100">
+                        <CircleStackIcon className="h-4 w-4 text-gray-500 dark:text-neutral-400" />
                         Cookies
                       </div>
                       <span>This tool currently uses no cookies.</span>
                     </div>
                   </div>
-                  <div className="mt-4 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800">
+                  <div className="mt-4 rounded-lg border border-amber-200 dark:border-amber-400/30 bg-amber-50 dark:bg-amber-400/10 px-3 py-2 text-xs text-amber-800 dark:text-amber-100">
                     This app is still in development. Found an issue? Report it on{' '}
                     <a
                       href="https://github.com/pillowbytes/replin-inspect/issues"
@@ -234,7 +292,7 @@ export default function HomePage() {
                     .
                   </div>
                 </div>
-                <div className="border border-gray-200 rounded-xl p-6 bg-gray-50">
+                <div className="border border-gray-200 dark:border-neutral-800 rounded-xl p-6 bg-gray-50 dark:bg-neutral-900/60">
                   {mode === 'network' && <UploadArea onParsed={handleParsed} />}
                   {mode === 'token' && <TokenInspector onDecoded={handleDecoded} />}
                 </div>
@@ -242,21 +300,21 @@ export default function HomePage() {
             </div>
 
             <div className="grid grid-cols-1 gap-6">
-              <div className="border border-gray-200 rounded-xl bg-white">
-                <div className="border-b border-gray-200 p-6">
+              <div className="border border-gray-200 dark:border-neutral-800 rounded-xl bg-white dark:bg-neutral-900">
+                <div className="border-b border-gray-200 dark:border-neutral-800 p-6">
                   <div className="space-y-2">
-                    <div className="flex items-center gap-2 text-sm font-semibold text-gray-900">
-                      <ClipboardDocumentListIcon className="h-4 w-4 text-gray-600" />
+                    <div className="flex items-center gap-2 text-sm font-semibold text-gray-900 dark:text-neutral-100">
+                      <ClipboardDocumentListIcon className="h-4 w-4 text-gray-600 dark:text-neutral-400" />
                       How to capture a high‑quality HAR
                     </div>
-                    <p className="text-sm text-gray-600">
+                    <p className="text-sm text-gray-600 dark:text-neutral-300">
                       Follow these steps to generate a HAR file that makes it easy to diagnose
                       performance issues, failed requests, and authentication problems.
                     </p>
                   </div>
                 </div>
 
-                <div className="border-b border-gray-200 px-6">
+                <div className="border-b border-gray-200 dark:border-neutral-800 px-6">
                   <div className="flex gap-2 text-sm">
                     {[
                       { id: 'chrome', label: 'Chrome' },
@@ -267,21 +325,21 @@ export default function HomePage() {
                       <button
                         key={tab.id}
                         onClick={() => setGuideTab(tab.id as typeof guideTab)}
-                        className={`px-3 py-2 border-b -mb-px font-medium ${
-                          guideTab === tab.id
-                            ? 'border-blue-600 text-blue-600'
-                            : 'border-transparent text-gray-500 hover:text-gray-700'
-                        }`}
-                      >
-                        {tab.label}
+                          className={`px-3 py-2 border-b -mb-px font-medium ${
+                            guideTab === tab.id
+                            ? 'border-blue-400 text-blue-400 dark:border-neutral-300 dark:text-neutral-100'
+                              : 'border-transparent text-gray-500 dark:text-neutral-400 hover:text-gray-700 dark:hover:text-neutral-200'
+                          }`}
+                        >
+                          {tab.label}
                       </button>
                     ))}
                   </div>
                 </div>
 
                 {guideTab === 'chrome' && (
-                  <div className="space-y-3 text-sm text-gray-600 p-6">
-                    <div className="font-semibold text-gray-900">Chrome</div>
+                  <div className="space-y-3 text-sm text-gray-600 dark:text-neutral-300 p-6">
+                    <div className="font-semibold text-gray-900 dark:text-neutral-100">Chrome</div>
                     <div>Use the Chrome DevTools Network panel:</div>
                     <ol className="space-y-3 list-decimal list-inside">
                       <li>In your browser, navigate to the page where you are encountering the issue.</li>
@@ -289,13 +347,13 @@ export default function HomePage() {
                       <li>In the DevTools panel, select the <strong>Network</strong> tab. The tool automatically begins recording network activity.</li>
                       <li>Select <strong>Preserve log</strong>.</li>
                       <li>
-                        Click <span className="inline-flex align-middle mx-1"><NoSymbolIcon className="h-4 w-4 text-gray-500" /></span>
+                        Click <span className="inline-flex align-middle mx-1"><NoSymbolIcon className="h-4 w-4 text-gray-500 dark:text-neutral-400" /></span>
                         <strong>Clear network log</strong>.
                       </li>
                       <li>Reproduce the issue by interacting with the site.</li>
                       <li>
                         When you're done reproducing the issue,
-                        <span className="inline-flex align-middle mx-1"><ArrowDownTrayIcon className="h-4 w-4 text-gray-500" /></span>
+                        <span className="inline-flex align-middle mx-1"><ArrowDownTrayIcon className="h-4 w-4 text-gray-500 dark:text-neutral-400" /></span>
                         <strong>Export HAR (sanitized)</strong> and save the generated HAR file.
                       </li>
                     </ol>
@@ -303,8 +361,8 @@ export default function HomePage() {
                 )}
 
                 {guideTab === 'edge' && (
-                  <div className="space-y-3 text-sm text-gray-600 p-6">
-                    <div className="font-semibold text-gray-900">Edge</div>
+                  <div className="space-y-3 text-sm text-gray-600 dark:text-neutral-300 p-6">
+                    <div className="font-semibold text-gray-900 dark:text-neutral-100">Edge</div>
                     <div>Use the Microsoft Edge DevTools Network tool:</div>
                     <ol className="space-y-3 list-decimal list-inside">
                       <li>In your browser, navigate to the page where you are encountering the issue.</li>
@@ -312,13 +370,13 @@ export default function HomePage() {
                       <li>In the DevTools panel, select the <strong>Network</strong> tab. The tool automatically begins recording network activity.</li>
                       <li>Select <strong>Preserve log</strong>.</li>
                       <li>
-                        Click <span className="inline-flex align-middle mx-1"><NoSymbolIcon className="h-4 w-4 text-gray-500" /></span>
+                        Click <span className="inline-flex align-middle mx-1"><NoSymbolIcon className="h-4 w-4 text-gray-500 dark:text-neutral-400" /></span>
                         <strong>Clear network log</strong>.
                       </li>
                       <li>Reproduce the issue by interacting with the site.</li>
                       <li>
                         When you're done reproducing the issue, click
-                        <span className="inline-flex align-middle mx-1"><ArrowDownTrayIcon className="h-4 w-4 text-gray-500" /></span>
+                        <span className="inline-flex align-middle mx-1"><ArrowDownTrayIcon className="h-4 w-4 text-gray-500 dark:text-neutral-400" /></span>
                         <strong>Export HAR</strong> and save the generated HAR file.
                       </li>
                     </ol>
@@ -326,25 +384,25 @@ export default function HomePage() {
                 )}
 
                 {guideTab === 'firefox' && (
-                  <div className="space-y-3 text-sm text-gray-600 p-6">
-                    <div className="font-semibold text-gray-900">Firefox</div>
+                  <div className="space-y-3 text-sm text-gray-600 dark:text-neutral-300 p-6">
+                    <div className="font-semibold text-gray-900 dark:text-neutral-100">Firefox</div>
                     <div>Use the Firefox DevTools Network Monitor:</div>
                     <ol className="space-y-3 list-decimal list-inside">
                       <li>In your browser, navigate to the page where you are encountering the issue.</li>
                       <li>Open Firefox DevTools: right-click anywhere on the page and choose <strong>Inspect</strong>.</li>
                       <li>In the DevTools panel, select the <strong>Network</strong> tab. The tool automatically begins recording network activity.</li>
                       <li>
-                        Click <span className="inline-flex align-middle mx-1"><Cog6ToothIcon className="h-4 w-4 text-gray-500" /></span>
+                        Click <span className="inline-flex align-middle mx-1"><Cog6ToothIcon className="h-4 w-4 text-gray-500 dark:text-neutral-400" /></span>
                         <strong>Settings</strong> and then select <strong>Persist Logs</strong>.
                       </li>
                       <li>
-                        Click <span className="inline-flex align-middle mx-1"><TrashIcon className="h-4 w-4 text-gray-500" /></span>
+                        Click <span className="inline-flex align-middle mx-1"><TrashIcon className="h-4 w-4 text-gray-500 dark:text-neutral-400" /></span>
                         <strong>Clear</strong>.
                       </li>
                       <li>Reproduce the issue by interacting with the site.</li>
                       <li>
                         When you're done reproducing the issue, click
-                        <span className="inline-flex align-middle mx-1"><Cog6ToothIcon className="h-4 w-4 text-gray-500" /></span>
+                        <span className="inline-flex align-middle mx-1"><Cog6ToothIcon className="h-4 w-4 text-gray-500 dark:text-neutral-400" /></span>
                         <strong>Settings &gt; Save All As HAR</strong> and save the generated HAR file.
                       </li>
                     </ol>
@@ -352,8 +410,8 @@ export default function HomePage() {
                 )}
 
                 {guideTab === 'safari' && (
-                  <div className="space-y-3 text-sm text-gray-600 p-6">
-                    <div className="font-semibold text-gray-900">Safari</div>
+                  <div className="space-y-3 text-sm text-gray-600 dark:text-neutral-300 p-6">
+                    <div className="font-semibold text-gray-900 dark:text-neutral-100">Safari</div>
                     <div>Use the Safari Web Inspector Network tab:</div>
                     <ol className="space-y-3 list-decimal list-inside">
                       <li>Enable Safari developer tools.</li>
@@ -362,21 +420,21 @@ export default function HomePage() {
                       <li>In the Web Inspector, select the <strong>Network</strong> tab. The tool automatically begins recording network activity.</li>
                       <li>Select <strong>Preserve Log</strong> and reload the web page.</li>
                       <li>
-                        Click <span className="inline-flex align-middle mx-1"><TrashIcon className="h-4 w-4 text-gray-500" /></span>
+                        Click <span className="inline-flex align-middle mx-1"><TrashIcon className="h-4 w-4 text-gray-500 dark:text-neutral-400" /></span>
                         <strong>Clear Network Items</strong>.
                       </li>
                       <li>Reproduce the issue by interacting with the site.</li>
                       <li>
                         When you're done reproducing the issue, click
-                        <span className="inline-flex align-middle mx-1"><ArrowDownTrayIcon className="h-4 w-4 text-gray-500" /></span>
+                        <span className="inline-flex align-middle mx-1"><ArrowDownTrayIcon className="h-4 w-4 text-gray-500 dark:text-neutral-400" /></span>
                         <strong>Export</strong> and save the generated HAR file.
                       </li>
                     </ol>
                   </div>
                 )}
 
-                <div className="border-t border-gray-200 p-4">
-                  <div className="rounded-lg border border-gray-200 bg-gray-50 p-4 text-xs text-gray-500">
+                <div className="border-t border-gray-200 dark:border-neutral-800 p-4">
+                  <div className="rounded-lg border border-gray-200 dark:border-neutral-800 bg-gray-50 dark:bg-neutral-800 p-4 text-xs text-gray-500 dark:text-neutral-400">
                     Tip: Capture both the failing request and a known‑good baseline to compare.
                   </div>
                 </div>
@@ -389,7 +447,7 @@ export default function HomePage() {
             {/* Summary strip */}
             {/* Command center layout */}
             <div className="grid grid-cols-1 lg:grid-cols-[220px_minmax(720px,1fr)_360px] lg:grid-rows-[minmax(0,1fr)] gap-6 flex-1 min-h-0 h-full w-full">
-              <aside className="space-y-4 lg:overflow-y-auto lg:pr-2 pb-2">
+              <aside className="space-y-4 lg:overflow-y-auto lg:pr-2 pb-2 no-scrollbar">
                 <FiltersPanel
                   selectedMethods={selectedMethods}
                   setSelectedMethods={setSelectedMethods}
@@ -399,30 +457,30 @@ export default function HomePage() {
                   setUrlQuery={setUrlQuery}
                 />
 
-                <div className="border border-gray-200 rounded-xl p-4 bg-white">
-                  <div className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+                <div className="border border-gray-200 dark:border-neutral-800 rounded-xl p-4 bg-white dark:bg-neutral-900">
+                  <div className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-neutral-400">
                     Findings
                   </div>
-                  <div className="mt-3 space-y-2 text-sm">
+                  <div className="mt-3 space-y-2 text-sm text-gray-700 dark:text-neutral-300">
                     <div className="flex items-center justify-between">
-                      <span className="text-gray-600">Total</span>
+                      <span className="text-gray-600 dark:text-neutral-400">Total</span>
                       <span className="font-medium">{findingsSummary.total}</span>
                     </div>
                     <div className="flex items-center justify-between">
-                      <span className="text-gray-600">Critical</span>
-                      <span className="font-medium text-red-600">
+                      <span className="text-gray-600 dark:text-neutral-400">Critical</span>
+                      <span className="font-medium text-red-600 dark:text-red-300">
                         {findingsSummary.critical}
                       </span>
                     </div>
                     <div className="flex items-center justify-between">
-                      <span className="text-gray-600">Warnings</span>
-                      <span className="font-medium text-amber-600">
+                      <span className="text-gray-600 dark:text-neutral-400">Warnings</span>
+                      <span className="font-medium text-amber-600 dark:text-amber-300">
                         {findingsSummary.warning}
                       </span>
                     </div>
                     <div className="flex items-center justify-between">
-                      <span className="text-gray-600">Info</span>
-                      <span className="font-medium text-gray-700">
+                      <span className="text-gray-600 dark:text-neutral-400">Info</span>
+                      <span className="font-medium text-gray-700 dark:text-neutral-200">
                         {findingsSummary.info}
                       </span>
                     </div>
@@ -432,7 +490,7 @@ export default function HomePage() {
                       onClick={() => setShowFindings(true)}
                       disabled
                       aria-disabled="true"
-                      className="mt-4 w-full text-sm px-3 py-2 border border-gray-200 rounded-md text-gray-400 cursor-not-allowed"
+                      className="mt-4 w-full text-sm px-3 py-2 border border-gray-200 dark:border-neutral-700 rounded-md text-gray-400 dark:text-neutral-500 cursor-not-allowed bg-white dark:bg-neutral-900"
                     >
                       Open findings
                     </button>
@@ -442,7 +500,7 @@ export default function HomePage() {
 
               <section className="min-h-0 flex flex-col pb-2">
                 <div className="mb-3 flex items-center justify-between">
-                  <div className="text-sm font-semibold text-gray-900">
+                  <div className="text-sm font-semibold text-gray-900 dark:text-neutral-100">
                     {showFindings ? 'Findings' : 'Requests'}
                   </div>
                   <div className="flex items-center gap-2 text-xs">
@@ -479,7 +537,7 @@ export default function HomePage() {
                     ) : (
                       <button
                         onClick={() => setShowFindings(false)}
-                        className="text-xs px-3 py-1.5 border border-gray-200 rounded-md hover:bg-gray-50"
+                        className="text-xs px-3 py-1.5 border border-gray-200 dark:border-neutral-700 rounded-md hover:bg-gray-50 dark:hover:bg-neutral-800 text-gray-700 dark:text-neutral-200"
                       >
                         Back to requests
                       </button>
@@ -491,7 +549,7 @@ export default function HomePage() {
                     <div
                       className="border border-gray-200 rounded-xl overflow-hidden flex-1 min-h-0"
                     >
-                      <div className="h-full overflow-y-auto p-4">
+                      <div className="h-full overflow-y-auto p-4 no-scrollbar">
                         <FindingsView
                           findings={findings}
                           requests={requests}
@@ -518,7 +576,7 @@ export default function HomePage() {
 
               <aside className="min-h-0 flex flex-col pb-2">
                 <div className="mb-3 flex items-center justify-between">
-                  <div className="text-sm font-semibold text-gray-900">
+                  <div className="text-sm font-semibold text-gray-900 dark:text-neutral-100">
                     Request details
                   </div>
                 </div>
@@ -562,11 +620,13 @@ function SummaryPill({
     'inline-flex items-center gap-2 rounded-lg border px-3 py-1.5 font-medium';
   const toneClass =
     tone === 'danger'
-      ? 'border-red-200 bg-red-50 text-red-700'
+      ? 'border-red-200 bg-red-50 text-red-700 dark:border-red-400/40 dark:bg-red-400/10 dark:text-red-200'
       : tone === 'warning'
-      ? 'border-amber-200 bg-amber-50 text-amber-700'
-      : 'border-gray-200 bg-white text-gray-700';
-  const activeClass = active ? 'ring-2 ring-offset-1 ring-gray-200' : '';
+      ? 'border-amber-200 bg-amber-50 text-amber-700 dark:border-amber-400/40 dark:bg-amber-400/10 dark:text-amber-200'
+      : 'border-gray-200 bg-white text-gray-700 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-200';
+  const activeClass = active
+    ? 'ring-2 ring-offset-1 ring-gray-200 dark:ring-neutral-700 dark:ring-offset-neutral-900'
+    : '';
 
   return (
     <button onClick={onClick} className={`${base} ${toneClass} ${activeClass}`}>
@@ -622,7 +682,7 @@ function Tooltip({
         pos &&
         createPortal(
           <span
-            className="pointer-events-none fixed z-[1000] -translate-x-1/2 -translate-y-full whitespace-nowrap rounded-md border border-gray-200 bg-white px-2 py-1 text-[10px] text-gray-700 shadow-sm"
+            className="pointer-events-none fixed z-[1000] -translate-x-1/2 -translate-y-full whitespace-nowrap rounded-md border border-gray-200 dark:border-neutral-700 bg-white dark:bg-neutral-900 px-2 py-1 text-[10px] text-gray-700 dark:text-neutral-200 shadow-sm"
             style={{ left: pos.left, top: pos.top - 8 }}
           >
             {label}

--- a/components/AnalysisTile.tsx
+++ b/components/AnalysisTile.tsx
@@ -85,11 +85,13 @@ export default function AnalysisTile({
     return (
       <div
         className={`${
-          embedded ? 'p-0 bg-transparent border-0' : 'border border-gray-200 rounded-xl p-4 bg-white'
+          embedded
+            ? 'p-0 bg-transparent border-0'
+            : 'border border-gray-200 dark:border-neutral-800 rounded-xl p-4 bg-white dark:bg-neutral-900'
         } flex items-center gap-2`}
       >
-        <CheckCircleIcon className="h-5 w-5 text-emerald-500" />
-        <div className="text-sm text-gray-700">
+        <CheckCircleIcon className="h-5 w-5 text-emerald-500 dark:text-emerald-300" />
+        <div className="text-sm text-gray-700 dark:text-neutral-300">
           No issues detected in this analysis.
         </div>
       </div>
@@ -99,13 +101,15 @@ export default function AnalysisTile({
   return (
     <div
       className={`${
-        embedded ? 'p-0 bg-transparent border-0' : 'border border-gray-200 rounded-xl p-4 bg-white'
+        embedded
+          ? 'p-0 bg-transparent border-0'
+          : 'border border-gray-200 dark:border-neutral-800 rounded-xl p-4 bg-white dark:bg-neutral-900'
       } space-y-4`}
     >
       {/* Header */}
       <div className="flex items-center gap-2">
-        <ExclamationTriangleIcon className="h-5 w-5 text-amber-500" />
-        <h2 className="text-sm font-semibold text-gray-900">
+        <ExclamationTriangleIcon className="h-5 w-5 text-amber-500 dark:text-amber-300" />
+        <h2 className="text-sm font-semibold text-gray-900 dark:text-neutral-100">
           Analysis summary
         </h2>
       </div>
@@ -142,7 +146,7 @@ export default function AnalysisTile({
                     {type.replace(/_/g, ' ')}
                   </span>
                 </div>
-                <span className="text-xs text-gray-500">
+                <span className="text-xs text-gray-500 dark:text-neutral-400">
                   {totalCount} requests
                 </span>
               </button>
@@ -166,7 +170,7 @@ export default function AnalysisTile({
                               [urlKey]: !s[urlKey],
                             }))
                           }
-                          className="flex items-center justify-between w-full text-left text-sm text-gray-700 hover:text-gray-900"
+                          className="flex items-center justify-between w-full text-left text-sm text-gray-700 dark:text-neutral-300 hover:text-gray-900 dark:hover:text-neutral-100"
                         >
                           <div className="flex items-center gap-2 min-w-0">
                             <ChevronDownIcon
@@ -180,7 +184,7 @@ export default function AnalysisTile({
                               </span>
                             </Tooltip>
                           </div>
-                          <span className="text-xs text-gray-500">
+                          <span className="text-xs text-gray-500 dark:text-neutral-400">
                             {allGroups.reduce((s, [, a]) => s + a.length, 0)}
                           </span>
                         </button>
@@ -196,21 +200,21 @@ export default function AnalysisTile({
                                   {/* Message header */}
                                   <div className="flex items-start justify-between text-sm">
                                     <div>
-                                      <div className="text-gray-900">
+                                      <div className="text-gray-900 dark:text-neutral-100">
                                         {msg}
                                       </div>
                                       {sample.confidence && (
-                                        <div className="text-[11px] text-gray-500">
+                                        <div className="text-[11px] text-gray-500 dark:text-neutral-400">
                                           Confidence: {sample.confidence}
                                         </div>
                                       )}
                                       {sample.suggestedAction && (
-                                        <div className="text-xs text-gray-500">
+                                        <div className="text-xs text-gray-500 dark:text-neutral-400">
                                           {sample.suggestedAction}
                                         </div>
                                       )}
                                     </div>
-                                    <span className="text-xs text-gray-500">
+                                    <span className="text-xs text-gray-500 dark:text-neutral-400">
                                       {items.length}
                                     </span>
                                   </div>
@@ -223,7 +227,7 @@ export default function AnalysisTile({
                                         [key]: !s[key],
                                       }))
                                     }
-                                    className="flex items-center gap-1 text-[11px] text-gray-500 hover:text-gray-700"
+                                    className="flex items-center gap-1 text-[11px] text-gray-500 dark:text-neutral-400 hover:text-gray-700 dark:hover:text-neutral-200"
                                   >
                                     <CodeBracketIcon className="h-3 w-3" />
                                     {hiddenJson[key]
@@ -232,7 +236,7 @@ export default function AnalysisTile({
                                   </button>
 
                                   {!hiddenJson[key] && (
-                                    <pre className="bg-gray-50 border border-gray-200 rounded-md p-2 text-[11px] font-mono overflow-x-auto">
+                                    <pre className="bg-gray-50 dark:bg-neutral-800 border border-gray-200 dark:border-neutral-700 rounded-md p-2 text-[11px] font-mono overflow-x-auto text-gray-800 dark:text-neutral-200">
 {JSON.stringify(
   {
     type: sample.type,
@@ -255,7 +259,7 @@ export default function AnalysisTile({
                                           f.relatedRequestId &&
                                           onSelectRequest(f.relatedRequestId)
                                         }
-                                        className="block w-full text-left text-xs text-gray-700 hover:text-blue-600"
+                                        className="block w-full text-left text-xs text-gray-700 hover:text-blue-600 dark:text-neutral-300 dark:hover:text-blue-200"
                                       >
                                         <Tooltip label={f.description}>
                                           <span>{msg}</span>
@@ -279,7 +283,7 @@ export default function AnalysisTile({
                                           [urlKey]: visible + 5,
                                         }))
                                       }
-                                      className="text-blue-600 hover:underline"
+                                      className="text-blue-600 hover:underline dark:text-blue-300 dark:hover:text-blue-200"
                                     >
                                       Show 5 more
                                     </button>
@@ -290,7 +294,7 @@ export default function AnalysisTile({
                                           [urlKey]: allGroups.length,
                                         }))
                                       }
-                                      className="text-blue-600 hover:underline"
+                                      className="text-blue-600 hover:underline dark:text-blue-300 dark:hover:text-blue-200"
                                     >
                                       Show all
                                     </button>
@@ -305,7 +309,7 @@ export default function AnalysisTile({
                                         [urlKey]: 5,
                                       }))
                                     }
-                                    className="text-gray-600 hover:text-gray-900"
+                                    className="text-gray-600 dark:text-neutral-300 hover:text-gray-900 dark:hover:text-neutral-100"
                                   >
                                     Show less
                                   </button>
@@ -373,7 +377,7 @@ function Tooltip({
         pos &&
         createPortal(
           <span
-            className="pointer-events-none fixed z-[1000] -translate-x-1/2 -translate-y-full whitespace-nowrap rounded-md border border-gray-200 bg-white px-2 py-1 text-[10px] text-gray-700 shadow-sm"
+            className="pointer-events-none fixed z-[1000] -translate-x-1/2 -translate-y-full whitespace-nowrap rounded-md border border-gray-200 dark:border-neutral-700 bg-white dark:bg-neutral-900 px-2 py-1 text-[10px] text-gray-700 dark:text-neutral-200 shadow-sm"
             style={{ left: pos.left, top: pos.top - 8 }}
           >
             {label}

--- a/components/FiltersPanel.tsx
+++ b/components/FiltersPanel.tsx
@@ -50,18 +50,21 @@ export default function FiltersPanel({
   };
 
   return (
-    <div className="border border-gray-200 rounded-xl p-4 bg-white" ref={dropdownRef}>
-      <div className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+    <div
+      className="border border-gray-200 dark:border-neutral-800 rounded-xl p-4 bg-white dark:bg-neutral-900"
+      ref={dropdownRef}
+    >
+      <div className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-neutral-400">
         Filters
       </div>
       <div className="mt-3 space-y-3 text-sm">
         <div className="relative">
-          <MagnifyingGlassIcon className="h-4 w-4 absolute left-2 top-1/2 -translate-y-1/2 text-gray-400" />
+          <MagnifyingGlassIcon className="h-4 w-4 absolute left-2 top-1/2 -translate-y-1/2 text-gray-400 dark:text-neutral-500" />
           <input
             value={urlQuery}
             onChange={(e) => setUrlQuery(e.target.value)}
             placeholder="Filter URL"
-            className="pl-8 pr-2 py-1.5 w-full border border-gray-200 rounded-md"
+            className="pl-8 pr-2 py-1.5 w-full border border-gray-200 dark:border-neutral-700 rounded-md bg-white dark:bg-neutral-800 text-gray-900 dark:text-neutral-100 placeholder:text-gray-400 dark:placeholder:text-gray-500"
           />
         </div>
 
@@ -173,14 +176,14 @@ function Dropdown({
       <button
         onClick={onToggle}
         aria-expanded={isOpen}
-        className="flex items-center gap-1 px-3 py-1.5 border border-gray-200 rounded-md hover:text-gray-900 text-xs"
+        className="flex items-center gap-1 px-3 py-1.5 border border-gray-200 dark:border-neutral-700 rounded-md hover:text-gray-900 dark:hover:text-neutral-100 text-xs text-gray-700 dark:text-neutral-200 bg-white dark:bg-neutral-800"
       >
         {label}
         <ChevronDownIcon className="h-4 w-4" />
       </button>
 
       {isOpen && (
-        <div className="absolute z-10 mt-1 w-36 bg-white border border-gray-200 rounded-md">
+        <div className="absolute z-10 mt-1 w-36 bg-white dark:bg-neutral-900 border border-gray-200 dark:border-neutral-700 rounded-md">
           {children}
         </div>
       )}
@@ -208,7 +211,7 @@ function DropdownOption({
   return (
     <div
       onClick={onClick}
-      className="flex items-center justify-between px-3 py-2 cursor-pointer hover:bg-gray-50 text-sm"
+      className="flex items-center justify-between px-3 py-2 cursor-pointer hover:bg-gray-50 dark:hover:bg-neutral-800 text-sm text-gray-700 dark:text-neutral-200"
     >
       <span className={active ? activeStyle : ''}>{children}</span>
       {active && <CheckIcon className="h-4 w-4" />}
@@ -232,7 +235,11 @@ function FilterChip({
       ? getMethodStyle(value ?? '')
       : variant === 'status'
       ? getStatusStyle(value ?? '')
-      : { border: 'border-emerald-200', bg: 'bg-emerald-50', text: 'text-emerald-700' };
+      : {
+          border: 'border-emerald-200 dark:border-emerald-400/40',
+          bg: 'bg-emerald-50 dark:bg-emerald-400/10',
+          text: 'text-emerald-700 dark:text-emerald-200',
+        };
 
   return (
     <div

--- a/components/FindingsView.tsx
+++ b/components/FindingsView.tsx
@@ -22,7 +22,7 @@ export default function FindingsView({
 
   if (findings.length === 0) {
     return (
-      <div className="border border-gray-200 rounded-xl p-6 text-sm text-gray-600 bg-white">
+      <div className="border border-gray-200 dark:border-neutral-800 rounded-xl p-6 text-sm text-gray-600 dark:text-neutral-300 bg-white dark:bg-neutral-900">
         No findings detected for this analysis.
       </div>
     );
@@ -32,7 +32,7 @@ export default function FindingsView({
     <div className="space-y-6 w-full min-w-0 max-w-full">
       {/* Top causes */}
       <div className="space-y-3">
-        <div className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+        <div className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-neutral-400">
           Top causes
         </div>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4 w-full max-w-full">
@@ -44,25 +44,25 @@ export default function FindingsView({
                   cause.sampleRequestId &&
                   onSelectRequest(cause.sampleRequestId)
                 }
-                className="text-left border border-gray-200 rounded-xl p-4 bg-white hover:bg-gray-50 w-full min-w-0 max-w-full"
+                className="text-left border border-gray-200 dark:border-neutral-800 rounded-xl p-4 bg-white dark:bg-neutral-900 hover:bg-gray-50 dark:hover:bg-neutral-800 w-full min-w-0 max-w-full"
               >
-                <div className="text-sm font-semibold text-gray-900">
+                <div className="text-sm font-semibold text-gray-900 dark:text-neutral-100">
                   {cause.title}
                 </div>
-                <div className="text-xs text-gray-600 mt-1 break-words">
+                <div className="text-xs text-gray-600 dark:text-neutral-300 mt-1 break-words">
                   {cause.summary}
                 </div>
                 {cause.confidence && (
-                  <div className="text-[11px] text-gray-500 mt-1">
+                  <div className="text-[11px] text-gray-500 dark:text-neutral-400 mt-1">
                     Confidence: {cause.confidence}
                   </div>
                 )}
                 {cause.evidence.length > 0 && (
-                  <div className="mt-2 text-xs text-gray-500 break-words">
+                  <div className="mt-2 text-xs text-gray-500 dark:text-neutral-400 break-words">
                     {cause.evidence.join(' · ')}
                   </div>
                 )}
-                <div className="mt-3 text-[11px] text-gray-400">
+                <div className="mt-3 text-[11px] text-gray-400 dark:text-neutral-500">
                   {cause.count} affected requests
                 </div>
               </button>
@@ -79,7 +79,7 @@ export default function FindingsView({
 
       {/* Affected requests */}
       <div className="space-y-3">
-        <div className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+        <div className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-neutral-400">
           Affected requests
         </div>
         <div className="space-y-2 w-full max-w-full">
@@ -87,19 +87,19 @@ export default function FindingsView({
             <button
               key={item.requestId}
               onClick={() => onSelectRequest(item.requestId)}
-              className="w-full text-left border border-gray-200 rounded-xl p-4 bg-gray-50 hover:bg-gray-100 min-w-0 max-w-full"
+              className="w-full text-left border border-gray-200 dark:border-neutral-800 rounded-xl p-4 bg-gray-50 dark:bg-neutral-900/60 hover:bg-gray-100 dark:hover:bg-neutral-800 min-w-0 max-w-full"
             >
-              <div className="text-sm font-medium text-gray-800 break-words">
+              <div className="text-sm font-medium text-gray-800 dark:text-neutral-100 break-words">
                 <span className="font-method">{item.method}</span>{' '}
-                <span className="text-xs text-gray-600">
+                <span className="text-xs text-gray-600 dark:text-neutral-300">
                   {item.path ?? item.url}
                 </span>
               </div>
-              <div className="text-xs text-gray-500 mt-1 break-words">
+              <div className="text-xs text-gray-500 dark:text-neutral-400 mt-1 break-words">
                 {item.causeTitle}
               </div>
               {item.evidence.length > 0 && (
-                <div className="mt-2 text-xs text-gray-500 break-words">
+                <div className="mt-2 text-xs text-gray-500 dark:text-neutral-400 break-words">
                   {item.evidence.join(' · ')}
                 </div>
               )}

--- a/components/RequestDetailsPanel.tsx
+++ b/components/RequestDetailsPanel.tsx
@@ -57,10 +57,10 @@ export default function RequestDetailsPanel({
   const activeTab = tabs.find((item) => item.id === tab) ?? tabs[0];
 
   return (
-    <div className="h-full flex border border-gray-200 rounded-xl overflow-hidden bg-white">
+    <div className="h-full flex border border-gray-200 dark:border-neutral-800 rounded-xl overflow-hidden bg-white dark:bg-neutral-900">
       <div className="flex-1 min-w-0 flex flex-col">
         <div
-          className={`h-10 px-4 border-b border-gray-200 text-xs font-semibold uppercase tracking-wide text-gray-500 flex items-center ${
+          className={`h-10 px-4 border-b border-gray-200 dark:border-neutral-800 text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-neutral-400 flex items-center ${
             isAtTop ? '' : 'shadow-sm'
           } ${topBump ? '-translate-y-0.5 scale-y-105' : ''} origin-top transition-transform`}
         >
@@ -87,7 +87,7 @@ export default function RequestDetailsPanel({
               );
             }
           }}
-          className="flex-1 overflow-y-auto overscroll-contain p-4 space-y-6 text-sm"
+          className="flex-1 overflow-y-auto overscroll-contain p-4 space-y-6 text-sm text-gray-900 dark:text-neutral-100 no-scrollbar"
         >
           {tab === 'overview' && (
             <OverviewTab request={request} findings={requestFindings} />
@@ -104,7 +104,7 @@ export default function RequestDetailsPanel({
         </div>
       </div>
 
-      <div className="flex w-10 flex-col items-center gap-2 border-l border-gray-200 bg-gray-50/60 pt-1 pb-3">
+      <div className="flex w-10 flex-col items-center gap-2 border-l border-gray-200 dark:border-neutral-800 bg-gray-50/60 dark:bg-neutral-900/60 pt-1 pb-3">
         {tabs.map((item) => (
           <TabRailButton
             key={item.id}
@@ -273,14 +273,14 @@ function BodySection({
 
       <button
         onClick={() => setOpen((v) => !v)}
-        className="flex items-center gap-1 text-xs text-gray-600 hover:text-gray-900"
+        className="flex items-center gap-1 text-xs text-gray-600 dark:text-neutral-300 hover:text-gray-900 dark:hover:text-neutral-100"
       >
         <ChevronDownIcon className={`h-4 w-4 transition-transform ${open ? 'rotate-180' : ''}`} />
         View body
       </button>
 
       {open && (
-        <pre className="mt-2 max-h-64 overflow-auto rounded-md bg-gray-50 p-3 text-xs font-mono text-gray-800">
+        <pre className="mt-2 max-h-64 overflow-auto rounded-md bg-gray-50 dark:bg-neutral-800 p-3 text-xs font-mono text-gray-800 dark:text-neutral-200 no-scrollbar">
           {body}
         </pre>
       )}
@@ -327,7 +327,7 @@ function HeadersTab({
         <>
           <button
             onClick={() => setShowAll((v) => !v)}
-            className="flex items-center gap-1 text-xs text-gray-600 hover:text-gray-900"
+            className="flex items-center gap-1 text-xs text-gray-600 dark:text-neutral-300 hover:text-gray-900 dark:hover:text-neutral-100"
           >
             <ChevronDownIcon className={`h-4 w-4 transition-transform ${showAll ? 'rotate-180' : ''}`} />
             All headers ({rest.length})
@@ -350,7 +350,7 @@ function HeadersTab({
 const TIMING_COLORS: Record<keyof HarTimings, string> = {
   blocked: 'bg-gray-400',
   dns: 'bg-purple-500',
-  connect: 'bg-blue-500',
+  connect: 'bg-blue-400',
   ssl: 'bg-indigo-500',
   send: 'bg-slate-500',
   wait: 'bg-amber-500',
@@ -406,7 +406,7 @@ function TimingTab({
               <span className={`h-2.5 w-2.5 rounded-full ${TIMING_COLORS[t.key]}`} />
               <span className="capitalize">{t.key}</span>
             </div>
-            <span className="tabular-nums text-gray-700">{t.value} ms</span>
+            <span className="tabular-nums text-gray-700 dark:text-neutral-200">{t.value} ms</span>
           </div>
         ))}
       </div>
@@ -427,7 +427,7 @@ function Section({
 }) {
   return (
     <div className="space-y-3">
-      <div className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+      <div className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-neutral-400">
         {title}
       </div>
       <div className="space-y-2">{children}</div>
@@ -450,9 +450,9 @@ function KeyValue({
 }) {
   return (
     <div className="flex flex-col gap-0.5">
-      <div className="text-xs text-gray-500">{label}</div>
+      <div className="text-xs text-gray-500 dark:text-neutral-400">{label}</div>
       <div
-        className={`text-sm text-gray-900 ${wrap ? 'break-all' : ''} ${
+        className={`text-sm text-gray-900 dark:text-neutral-100 ${wrap ? 'break-all' : ''} ${
           mono ? 'font-mono' : ''
         } ${className ?? ''}`}
       >
@@ -487,21 +487,21 @@ function FindingsBlock({
   return (
     <div className="space-y-3">
       {showSummary && (
-        <div className="grid grid-cols-3 gap-2 text-[11px] text-gray-500">
+        <div className="grid grid-cols-3 gap-2 text-[11px] text-gray-500 dark:text-neutral-400">
           <div className={`rounded-md border ${summaryStyles('critical')} px-2 py-1`}>
-            <span className="font-semibold text-gray-900">
+            <span className="font-semibold text-gray-900 dark:text-neutral-100">
               {counts.critical}
             </span>{' '}
             Critical
           </div>
           <div className={`rounded-md border ${summaryStyles('warning')} px-2 py-1`}>
-            <span className="font-semibold text-gray-900">
+            <span className="font-semibold text-gray-900 dark:text-neutral-100">
               {counts.warning}
             </span>{' '}
             Warnings
           </div>
           <div className={`rounded-md border ${summaryStyles('info')} px-2 py-1`}>
-            <span className="font-semibold text-gray-900">
+            <span className="font-semibold text-gray-900 dark:text-neutral-100">
               {counts.info}
             </span>{' '}
             Info
@@ -510,7 +510,7 @@ function FindingsBlock({
       )}
 
       {visible.length === 0 && info.length > 0 && (
-        <div className="text-xs text-gray-500">
+        <div className="text-xs text-gray-500 dark:text-neutral-400">
           No critical or warning findings for this section.
         </div>
       )}
@@ -519,22 +519,22 @@ function FindingsBlock({
         {visible.map((f, i) => (
           <div
             key={`${f.type}-${i}`}
-            className={`border border-gray-200 rounded-md p-3 ${severityCard(f.severity)} border-l-2 ${severityBorder(f.severity)}`}
+            className={`border border-gray-200 dark:border-neutral-800 rounded-md p-3 ${severityCard(f.severity)} border-l-2 ${severityBorder(f.severity)}`}
           >
-            <div className="flex items-center gap-2 text-[11px] text-gray-500">
+            <div className="flex items-center gap-2 text-[11px] text-gray-500 dark:text-neutral-400">
               <Tooltip label={severityLabel(f.severity)}>
                 <span className={`h-2 w-2 rounded-full ${severityDot(f.severity)}`} />
               </Tooltip>
               {f.confidence && (
-                <span className="text-gray-400">
+                <span className="text-gray-400 dark:text-neutral-500">
                   Confidence: {f.confidence}
                 </span>
               )}
             </div>
-            <div className="mt-2 text-sm text-gray-800 break-words">
+            <div className="mt-2 text-sm text-gray-800 dark:text-neutral-100 break-words">
               {formatFindingText(f.description)}
             </div>
-            <div className="mt-1 text-xs font-semibold text-gray-600 break-words">
+            <div className="mt-1 text-xs font-semibold text-gray-600 dark:text-neutral-300 break-words">
               {formatFindingText(f.suggestedAction)}
             </div>
           </div>
@@ -544,7 +544,7 @@ function FindingsBlock({
       {info.length > 0 && (
         <button
           onClick={() => setShowAll((v) => !v)}
-          className="text-xs text-gray-600 hover:text-gray-900"
+          className="text-xs text-gray-600 dark:text-neutral-400 hover:text-gray-900 dark:hover:text-neutral-200"
         >
           {showAll
             ? 'Hide info findings'
@@ -581,7 +581,11 @@ function KeyValueList({
 }
 
 function EmptyState({ text }: { text: string }) {
-  return <div className="text-sm text-gray-500 py-6 text-center">{text}</div>;
+  return (
+    <div className="text-sm text-gray-500 dark:text-neutral-400 py-6 text-center">
+      {text}
+    </div>
+  );
 }
 
 function TabRailButton({
@@ -603,14 +607,14 @@ function TabRailButton({
       aria-label={label}
       className={`relative flex h-8 w-8 items-center justify-center transition ${
         active
-          ? 'text-blue-600'
-          : 'text-gray-500 hover:text-gray-900'
+          ? 'text-blue-500 dark:text-neutral-100'
+          : 'text-gray-500 dark:text-neutral-400 hover:text-gray-900 dark:hover:text-neutral-200'
       }`}
     >
       <Icon className="h-5 w-5" />
       {active && (
         <span
-          className={`absolute top-1/2 h-6 w-1 -translate-y-1/2 bg-blue-600 ${
+          className={`absolute top-1/2 h-6 w-1 -translate-y-1/2 bg-blue-400 dark:bg-neutral-300 ${
             side === 'right'
               ? 'left-0 rounded-r-full'
               : 'right-0 rounded-l-full'
@@ -701,7 +705,7 @@ function Tooltip({
         pos &&
         createPortal(
           <span
-            className="pointer-events-none fixed z-[1000] -translate-x-1/2 -translate-y-full whitespace-nowrap rounded-md border border-gray-200 bg-white px-2 py-1 text-[10px] text-gray-700 shadow-sm"
+            className="pointer-events-none fixed z-[1000] -translate-x-1/2 -translate-y-full whitespace-nowrap rounded-md border border-gray-200 dark:border-neutral-700 bg-white dark:bg-neutral-900 px-2 py-1 text-[10px] text-gray-700 dark:text-neutral-200 shadow-sm"
             style={{ left: pos.left, top: pos.top - 8 }}
           >
             {label}
@@ -745,21 +749,21 @@ function highestSeverity(findings: Finding[]) {
 }
 
 function severityDot(severity: Finding['severity']) {
-  if (severity === 'critical') return 'bg-red-500';
-  if (severity === 'warning') return 'bg-amber-500';
-  return 'bg-gray-300';
+  if (severity === 'critical') return 'bg-red-500 dark:bg-red-400';
+  if (severity === 'warning') return 'bg-amber-500 dark:bg-amber-400';
+  return 'bg-gray-300 dark:bg-neutral-600';
 }
 
 function severityBorder(severity: Finding['severity']) {
-  if (severity === 'critical') return 'border-l-red-500';
-  if (severity === 'warning') return 'border-l-amber-400';
-  return 'border-l-gray-300';
+  if (severity === 'critical') return 'border-l-red-500 dark:border-l-red-400';
+  if (severity === 'warning') return 'border-l-amber-400 dark:border-l-amber-300';
+  return 'border-l-gray-300 dark:border-l-neutral-600';
 }
 
 function summaryStyles(severity: Finding['severity']) {
-  if (severity === 'critical') return 'border-red-200 bg-red-50';
-  if (severity === 'warning') return 'border-amber-200 bg-amber-50';
-  return 'border-gray-200 bg-gray-50';
+  if (severity === 'critical') return 'border-red-200 bg-red-50 dark:border-red-400/40 dark:bg-red-400/10';
+  if (severity === 'warning') return 'border-amber-200 bg-amber-50 dark:border-amber-400/40 dark:bg-amber-400/10';
+  return 'border-gray-200 bg-gray-50 dark:border-neutral-700 dark:bg-neutral-800/40';
 }
 
 function severityLabel(severity: Finding['severity']) {
@@ -769,9 +773,9 @@ function severityLabel(severity: Finding['severity']) {
 }
 
 function severityCard(severity: Finding['severity']) {
-  if (severity === 'critical') return 'bg-red-50';
-  if (severity === 'warning') return 'bg-amber-50';
-  return 'bg-gray-50';
+  if (severity === 'critical') return 'bg-red-50 dark:bg-red-400/10';
+  if (severity === 'warning') return 'bg-amber-50 dark:bg-amber-400/10';
+  return 'bg-gray-50 dark:bg-neutral-800/40';
 }
 
 function formatFindingText(text: string) {
@@ -779,7 +783,7 @@ function formatFindingText(text: string) {
   return parts.map((part, index) => {
     if (part.match(/^(https?:\/\/|wss?:\/\/)/)) {
       return (
-        <span key={index} className="text-xs text-gray-600 break-all">
+        <span key={index} className="text-xs text-gray-600 dark:text-neutral-300 break-all">
           {part}
         </span>
       );

--- a/components/ResultsTable.tsx
+++ b/components/ResultsTable.tsx
@@ -60,7 +60,7 @@ function statusToClass(status: number): StatusClass {
 }
 
 function statusColor(status: number) {
-  if (status < 200) return 'text-gray-900';
+  if (status < 200) return 'text-gray-900 dark:text-neutral-200';
   return getStatusText(statusToClass(status));
 }
 
@@ -72,12 +72,12 @@ function durationBarColor(ms: number) {
 
 function durationTextStyle(ms: number) {
   if (ms >= VERY_SLOW_REQUEST_MS) {
-    return 'text-red-600 font-semibold';
+    return 'text-red-600 dark:text-red-300 font-semibold';
   }
   if (ms >= SLOW_REQUEST_MS) {
-    return 'text-amber-600 font-semibold';
+    return 'text-amber-600 dark:text-amber-300 font-semibold';
   }
-  return 'text-emerald-600';
+  return 'text-emerald-600 dark:text-emerald-300';
 }
 
 function sizeLabel(bytes?: number) {
@@ -92,7 +92,7 @@ const TIMING_COLORS: Record<
 > = {
   blocked: 'bg-gray-400',
   dns: 'bg-purple-500',
-  connect: 'bg-blue-500',
+  connect: 'bg-blue-400',
   ssl: 'bg-indigo-500',
   send: 'bg-slate-500',
   wait: 'bg-amber-500',
@@ -256,7 +256,7 @@ export default function ResultsTable({
   return (
     <div className="flex flex-col min-h-0 h-full gap-3" ref={containerRef}>
       {/* Rows */}
-      <div className="border border-gray-200 rounded-xl overflow-hidden flex-1 min-h-0">
+      <div className="border border-gray-200 dark:border-neutral-800 rounded-xl overflow-hidden flex-1 min-h-0 bg-white dark:bg-neutral-900">
         <div
           ref={scrollRef}
           onScroll={() => {
@@ -276,10 +276,10 @@ export default function ResultsTable({
               );
             }
           }}
-          className="h-full overflow-y-auto overscroll-contain pb-2"
+          className="h-full overflow-y-auto overscroll-contain pb-2 no-scrollbar"
         >
           <div
-            className={`sticky top-0 z-10 bg-white border-b border-gray-200 grid grid-cols-[120px_1fr_240px] items-center px-3 py-2 text-xs text-gray-500 uppercase tracking-wide ${
+            className={`sticky top-0 z-10 bg-white dark:bg-neutral-900 border-b border-gray-200 dark:border-neutral-800 grid grid-cols-[120px_1fr_240px] items-center px-3 py-2 text-xs text-gray-500 dark:text-neutral-400 uppercase tracking-wide ${
               isAtTop ? '' : 'shadow-sm'
             } ${topBump ? '-translate-y-0.5 scale-y-105' : ''} origin-top transition-transform`}
           >
@@ -290,7 +290,7 @@ export default function ResultsTable({
                   sortColumn === 'time' ? (d === 'asc' ? 'desc' : 'asc') : 'asc'
                 );
               }}
-              className="flex items-center gap-1 text-left hover:text-gray-700"
+              className="flex items-center gap-1 text-left hover:text-gray-700 dark:hover:text-neutral-200"
             >
               <ClockIcon className="h-3 w-3" />
               Time
@@ -301,15 +301,15 @@ export default function ResultsTable({
                   <BarsArrowDownIcon className="h-3 w-3" />
                 ))}
             </button>
-            <div className="space-y-1">
-              <div>Request</div>
-              <div className="flex items-center gap-3 text-[10px] text-gray-400 normal-case tracking-normal">
-                <span>Status</span>
-                <span>Type</span>
-                <span>Size sent → recv</span>
-                <span>Findings</span>
+              <div className="space-y-1">
+                <div>Request</div>
+                <div className="flex items-center gap-3 text-[10px] text-gray-400 dark:text-neutral-500 normal-case tracking-normal">
+                  <span>Status</span>
+                  <span>Type</span>
+                  <span>Size sent → recv</span>
+                  <span>Findings</span>
+                </div>
               </div>
-            </div>
             <button
               onClick={() => {
                 setSortColumn('duration');
@@ -317,7 +317,7 @@ export default function ResultsTable({
                   sortColumn === 'duration' ? (d === 'asc' ? 'desc' : 'asc') : 'desc'
                 );
               }}
-              className="flex items-center justify-end gap-1 text-right hover:text-gray-700"
+              className="flex items-center justify-end gap-1 text-right hover:text-gray-700 dark:hover:text-neutral-200"
             >
               Timing
               {sortColumn === 'duration' &&
@@ -357,28 +357,28 @@ export default function ResultsTable({
                   onSelectRequest?.(req.id);
                 }
               }}
-              className={`grid grid-cols-[120px_1fr_240px] items-center px-3 py-3 cursor-pointer hover:bg-gray-50 focus:outline-none ${
+              className={`grid grid-cols-[120px_1fr_240px] items-center px-3 py-3 cursor-pointer hover:bg-gray-50 dark:hover:bg-neutral-800 focus:outline-none ${
                 selected
-                  ? 'bg-white ring-1 ring-slate-300 border-l-4 border-blue-500 shadow-sm'
+                  ? 'bg-gray-100 dark:bg-neutral-800 ring-1 ring-slate-300 dark:ring-neutral-700 border-l-4 border-blue-400 dark:border-neutral-300 shadow-sm'
                   : ''
               }`}
             >
               {/* Time */}
-              <div className="flex items-center gap-1 text-xs text-gray-500">
+              <div className="flex items-center gap-1 text-xs text-gray-500 dark:text-neutral-400">
                 <ClockIcon className="h-3 w-3 shrink-0" />
                 <span>{formatTime(req.startTime)}</span>
               </div>
 
               {/* Request info */}
               <div className="space-y-1 overflow-hidden">
-                <div className="truncate text-sm font-medium">
+                <div className="truncate text-sm font-medium text-gray-900 dark:text-neutral-100">
                   <span className={`font-method mr-2 ${getMethodStyle(req.method).text}`}>
                     {req.method}
                   </span>
                   {req.url}
                 </div>
 
-                <div className="flex items-center gap-3 text-xs text-gray-600">
+                <div className="flex items-center gap-3 text-xs text-gray-600 dark:text-neutral-300">
                   <Tooltip label="HTTP status code from the response.">
                     <span className={statusColor(req.status)}>
                       {req.status}
@@ -405,7 +405,7 @@ export default function ResultsTable({
 
                   {findings.length > 0 && (
                     <Tooltip label="Issues detected for this request.">
-                      <span className="flex items-center gap-1 text-amber-600">
+                      <span className="flex items-center gap-1 text-amber-600 dark:text-amber-300">
                         <ExclamationTriangleIcon className="h-3 w-3" />
                         {findings.length}
                       </span>
@@ -418,7 +418,7 @@ export default function ResultsTable({
               <div className="flex items-center gap-2">
                 {timingItems.length > 0 ? (
                   <>
-                    <div className="h-4 w-[70%] bg-gray-200 rounded-sm flex overflow-hidden">
+                    <div className="h-4 w-[70%] bg-gray-200 dark:bg-neutral-800 rounded-sm flex overflow-hidden">
                       {timingItems.map((t) => {
                         const label = `${t.key} (${t.value} ms)`;
                         const width = Math.max(1, (t.value / timingTotal) * 100);
@@ -439,8 +439,8 @@ export default function ResultsTable({
                     </div>
                   </>
                 ) : (
-                  <div className="flex items-center justify-between w-full text-xs text-gray-400">
-                    <div className="h-4 w-[70%] rounded-sm border border-dashed border-gray-300" />
+                  <div className="flex items-center justify-between w-full text-xs text-gray-400 dark:text-neutral-500">
+                    <div className="h-4 w-[70%] rounded-sm border border-dashed border-gray-300 dark:border-neutral-700" />
                     <Tooltip label="Timing data not available in this HAR entry.">
                       <span className="ml-2 w-16 text-right">No timing</span>
                     </Tooltip>
@@ -452,7 +452,7 @@ export default function ResultsTable({
         })}
 
         {filtered.length === 0 && (
-          <div className="px-4 py-6 text-center text-sm text-gray-500">
+          <div className="px-4 py-6 text-center text-sm text-gray-500 dark:text-neutral-400">
             No requests match the selected filters.
           </div>
         )}
@@ -544,7 +544,7 @@ function Tooltip({
         pos &&
         createPortal(
           <span
-            className="pointer-events-none fixed z-[1000] -translate-x-1/2 -translate-y-full whitespace-nowrap rounded-md border border-gray-200 bg-white px-2 py-1 text-[10px] text-gray-700 shadow-sm"
+            className="pointer-events-none fixed z-[1000] -translate-x-1/2 -translate-y-full whitespace-nowrap rounded-md border border-gray-200 dark:border-neutral-700 bg-white dark:bg-neutral-900 px-2 py-1 text-[10px] text-gray-700 dark:text-neutral-200 shadow-sm"
             style={{ left: pos.left, top: pos.top - 8 }}
           >
             {label}

--- a/components/UploadArea.tsx
+++ b/components/UploadArea.tsx
@@ -35,7 +35,7 @@ export default function UploadArea({ onParsed }: UploadAreaProps) {
   };
 
   return (
-    <div className="border border-gray-200 rounded-xl p-6 text-center">
+    <div className="border border-gray-200 dark:border-neutral-800 rounded-xl p-6 text-center bg-white dark:bg-neutral-900">
       {/* Hidden input */}
       <input
         ref={inputRef}
@@ -50,16 +50,18 @@ export default function UploadArea({ onParsed }: UploadAreaProps) {
       <label
         onClick={() => !isLoading && inputRef.current?.click()}
         className={`flex flex-col items-center justify-center gap-3 cursor-pointer select-none ${
-          isLoading ? 'opacity-60 cursor-not-allowed' : 'hover:bg-gray-50'
+          isLoading
+            ? 'opacity-60 cursor-not-allowed'
+            : 'hover:bg-gray-50 dark:hover:bg-neutral-800'
         } rounded-lg p-6 transition`}
       >
-        <ArrowUpTrayIcon className="h-6 w-6 text-gray-700" />
+        <ArrowUpTrayIcon className="h-6 w-6 text-gray-700 dark:text-neutral-200" />
 
-        <div className="text-sm font-medium text-gray-900">
+        <div className="text-sm font-medium text-gray-900 dark:text-neutral-100">
           {isLoading ? 'Analyzing HAR file…' : 'Start inspecting'}
         </div>
 
-        <div className="text-xs text-gray-500">
+        <div className="text-xs text-gray-500 dark:text-neutral-400">
           Click to select a .har file from your computer
         </div>
       </label>

--- a/lib/utils/filterStyles.ts
+++ b/lib/utils/filterStyles.ts
@@ -1,46 +1,90 @@
 export function getMethodStyle(method: string) {
   switch (method.toUpperCase()) {
     case 'GET':
-      return { border: 'border-emerald-200', bg: 'bg-emerald-50', text: 'text-emerald-700' };
+      return {
+        border: 'border-emerald-200 dark:border-emerald-400/40',
+        bg: 'bg-emerald-50 dark:bg-emerald-400/10',
+        text: 'text-emerald-700 dark:text-emerald-300',
+      };
     case 'POST':
-      return { border: 'border-blue-200', bg: 'bg-blue-50', text: 'text-blue-700' };
+      return {
+        border: 'border-blue-200 dark:border-blue-400/40',
+        bg: 'bg-blue-50 dark:bg-blue-400/10',
+        text: 'text-blue-700 dark:text-blue-300',
+      };
     case 'PUT':
-      return { border: 'border-violet-200', bg: 'bg-violet-50', text: 'text-violet-700' };
+      return {
+        border: 'border-violet-200 dark:border-violet-400/40',
+        bg: 'bg-violet-50 dark:bg-violet-400/10',
+        text: 'text-violet-700 dark:text-violet-200',
+      };
     case 'PATCH':
-      return { border: 'border-amber-200', bg: 'bg-amber-50', text: 'text-amber-700' };
+      return {
+        border: 'border-amber-200 dark:border-amber-400/40',
+        bg: 'bg-amber-50 dark:bg-amber-400/10',
+        text: 'text-amber-700 dark:text-amber-200',
+      };
     case 'DELETE':
-      return { border: 'border-red-200', bg: 'bg-red-50', text: 'text-red-700' };
+      return {
+        border: 'border-red-200 dark:border-red-400/40',
+        bg: 'bg-red-50 dark:bg-red-400/10',
+        text: 'text-red-700 dark:text-red-200',
+      };
     default:
-      return { border: 'border-slate-200', bg: 'bg-slate-50', text: 'text-slate-700' };
+      return {
+        border: 'border-slate-200 dark:border-neutral-600/40',
+        bg: 'bg-slate-50 dark:bg-neutral-800/40',
+        text: 'text-slate-700 dark:text-neutral-200',
+      };
   }
 }
 
 export function getStatusStyle(status: string) {
   switch (status) {
     case '2xx':
-      return { border: 'border-emerald-600', bg: 'bg-emerald-600', text: 'text-white' };
+      return {
+        border: 'border-emerald-600 dark:border-emerald-400/60',
+        bg: 'bg-emerald-600 dark:bg-emerald-400/30',
+        text: 'text-white dark:text-emerald-100',
+      };
     case '3xx':
-      return { border: 'border-blue-600', bg: 'bg-blue-600', text: 'text-white' };
+      return {
+        border: 'border-blue-600 dark:border-blue-400/60',
+        bg: 'bg-blue-600 dark:bg-blue-400/30',
+        text: 'text-white dark:text-blue-100',
+      };
     case '4xx':
-      return { border: 'border-amber-600', bg: 'bg-amber-600', text: 'text-white' };
+      return {
+        border: 'border-amber-600 dark:border-amber-400/60',
+        bg: 'bg-amber-600 dark:bg-amber-400/30',
+        text: 'text-white dark:text-amber-100',
+      };
     case '5xx':
-      return { border: 'border-red-600', bg: 'bg-red-600', text: 'text-white' };
+      return {
+        border: 'border-red-600 dark:border-red-400/60',
+        bg: 'bg-red-600 dark:bg-red-400/30',
+        text: 'text-white dark:text-red-100',
+      };
     default:
-      return { border: 'border-slate-600', bg: 'bg-slate-600', text: 'text-white' };
+      return {
+        border: 'border-slate-600 dark:border-neutral-600/60',
+        bg: 'bg-slate-600 dark:bg-neutral-600/30',
+        text: 'text-white dark:text-neutral-100',
+      };
   }
 }
 
 export function getStatusText(status: string) {
   switch (status) {
     case '2xx':
-      return 'text-emerald-700';
+      return 'text-emerald-700 dark:text-emerald-200';
     case '3xx':
-      return 'text-blue-700';
+      return 'text-blue-700 dark:text-blue-200';
     case '4xx':
-      return 'text-amber-700';
+      return 'text-amber-700 dark:text-amber-200';
     case '5xx':
-      return 'text-red-700';
+      return 'text-red-700 dark:text-red-200';
     default:
-      return 'text-gray-900';
+      return 'text-gray-900 dark:text-neutral-200';
   }
 }


### PR DESCRIPTION
## Summary
Refine the dark theme to a neutral palette, improve contrast for active/severity accents, and hide scrollbars across scrollable components.

## Changes
- app/globals.css: add `no-scrollbar` utility and update dark base colors.
- app/layout.tsx: align layout with theme variables.
- app/page.tsx: adjust active tab colors, warning/summary contrast, and apply scrollbar hiding.
- components/ResultsTable.tsx: selected row/hover parity, dark-mode contrast for status/duration, hide scrollbars.
- components/RequestDetailsPanel.tsx: severity colors/rails updated for the neutral dark palette, hide scrollbars in content/pre.
- components/AnalysisTile.tsx: dark-mode contrast tweaks for links/icons.
- components/FiltersPanel.tsx: chip styling for dark mode.
- components/FindingsView.tsx: dark palette alignment for cards.
- components/UploadArea.tsx: dark palette alignment for upload panel.
- lib/utils/filterStyles.ts: add dark variants for method/status colors; boost POST/GET saturation in dark mode.

## Testing
Not run (UI-only changes).
