### PR TITLE
Add SEO metadata, sitemap/robots, and OG banner

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -12,9 +12,58 @@ const jetbrainsMono = JetBrains_Mono({
   subsets: ['latin'],
 });
 
+const siteTitle = 'Replin Inspect';
+const siteDescription =
+  'Replin Inspect is a local-first HAR analysis tool for support engineers. Inspect HAR files, troubleshoot API failures, and analyze network timing safely in the browser.';
+
 export const metadata: Metadata = {
-  title: 'Replin Inspect',
-  description: 'Client‑side troubleshooting tool for network and auth analysis',
+  metadataBase: new URL('https://inspect.replin.ai'),
+  title: {
+    default: siteTitle,
+    template: `%s | ${siteTitle}`,
+  },
+  description: siteDescription,
+  keywords: [
+    'HAR analysis',
+    'HAR file inspection',
+    'HAR troubleshooting',
+    'support engineering tools',
+    'local diagnostics',
+    'network analysis',
+    'network troubleshooting',
+    'technical support',
+    'support tools',
+    'safe HAR analysis',
+    'local HAR analysis',
+    'troubleshooting HAR files',
+    'Replin Inspect',
+    'Replin Tools',
+    'Replin.ai',
+  ],
+  alternates: {
+    canonical: '/',
+  },
+  openGraph: {
+    type: 'website',
+    url: 'https://inspect.replin.ai',
+    siteName: siteTitle,
+    title: 'Replin Inspect — Local HAR Analysis & Troubleshooting',
+    description: siteDescription,
+    images: [
+      {
+        url: '/og.svg',
+        width: 1200,
+        height: 630,
+        alt: 'Replin Inspect — Local HAR Analysis & Troubleshooting',
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Replin Inspect — Local HAR Analysis & Troubleshooting',
+    description: siteDescription,
+    images: ['/og.svg'],
+  },
 };
 
 export default function RootLayout({

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -45,6 +45,26 @@ type ThemePreference = 'system' | 'light' | 'dark';
 type GuideTab = 'chrome' | 'edge' | 'firefox' | 'safari';
 
 export default function HomePage() {
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'SoftwareApplication',
+    name: 'Replin Inspect',
+    applicationCategory: 'DeveloperApplication',
+    operatingSystem: 'Web',
+    url: 'https://inspect.replin.ai',
+    description:
+      'Local-first HAR inspection and troubleshooting tool for support engineers. Analyze network requests, timings, and failures directly in the browser.',
+    publisher: {
+      '@type': 'Organization',
+      name: 'Pillowbytes',
+    },
+    offers: {
+      '@type': 'Offer',
+      price: '0',
+      priceCurrency: 'USD',
+    },
+  };
+
   const [analysisStarted, setAnalysisStarted] = useState(false);
   const [showOverlay, setShowOverlay] = useState(false);
   const [mode, setMode] = useState<AnalysisMode>('network');
@@ -295,6 +315,11 @@ export default function HomePage() {
     <div
       className="flex flex-col h-screen"
     >
+      <script
+        type="application/ld+json"
+        // eslint-disable-next-line react/no-danger
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
       <header className="w-full border-b border-utility-border bg-utility-main">
         <div
           className="w-full grid items-center gap-0 py-3 transition-[grid-template-columns] duration-300"

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,13 @@
+import type { MetadataRoute } from 'next';
+
+export const dynamic = 'force-static';
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+    },
+    sitemap: 'https://inspect.replin.ai/sitemap.xml',
+  };
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,14 @@
+import type { MetadataRoute } from 'next';
+
+export const dynamic = 'force-static';
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return [
+    {
+      url: 'https://inspect.replin.ai/',
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 1,
+    },
+  ];
+}

--- a/public/og.svg
+++ b/public/og.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" fill="none">
+  <rect width="1200" height="630" fill="#0A0A0A"/>
+  <rect x="60" y="60" width="1080" height="510" rx="32" fill="#111111" stroke="#1F2937" stroke-width="2"/>
+
+  <g transform="translate(110 120)">
+    <rect width="88" height="88" rx="20" fill="#0F172A" stroke="#1F2937" stroke-width="2"/>
+    <g transform="translate(12 12)">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="64" height="64" fill="#38BDF8">
+        <path d="M11.644 1.59a.75.75 0 0 1 .712 0l9.75 5.25a.75.75 0 0 1 0 1.32l-9.75 5.25a.75.75 0 0 1-.712 0l-9.75-5.25a.75.75 0 0 1 0-1.32l9.75-5.25Z"/>
+        <path d="m3.265 10.602 7.668 4.129a2.25 2.25 0 0 0 2.134 0l7.668-4.13 1.37.739a.75.75 0 0 1 0 1.32l-9.75 5.25a.75.75 0 0 1-.71 0l-9.75-5.25a.75.75 0 0 1 0-1.32l1.37-.738Z"/>
+        <path d="m10.933 19.231-7.668-4.13-1.37.739a.75.75 0 0 0 0 1.32l9.75 5.25c.221.12.489.12.71 0l9.75-5.25a.75.75 0 0 0 0-1.32l-1.37-.738-7.668 4.13a2.25 2.25 0 0 1-2.134-.001Z"/>
+      </svg>
+    </g>
+  </g>
+
+  <text x="230" y="170" font-family="Inter, Arial, sans-serif" font-weight="700" font-size="44" fill="#F9FAFB">
+    Replin Inspect
+  </text>
+
+  <text x="110" y="255" font-family="Inter, Arial, sans-serif" font-weight="600" font-size="36" fill="#E2E8F0">
+    Local HAR analysis & troubleshooting
+  </text>
+
+  <text x="110" y="315" font-family="Inter, Arial, sans-serif" font-size="24" fill="#94A3B8">
+    Inspect HAR files · Analyze network timing · Diagnose API failures
+  </text>
+
+  <rect x="110" y="360" width="210" height="44" rx="12" fill="#38BDF8"/>
+  <text x="135" y="390" font-family="Inter, Arial, sans-serif" font-weight="600" font-size="20" fill="#0A0A0A">
+    Open Replin Inspect
+  </text>
+
+  <text x="110" y="480" font-family="JetBrains Mono, SFMono-Regular, monospace" font-size="16" fill="#64748B" letter-spacing="1.4">
+    INSPECT.REPLIN.AI
+  </text>
+</svg>


### PR DESCRIPTION
## Summary
- Added full SEO metadata for Replin Inspect (canonical, OpenGraph, Twitter, keyword targeting).
- Added sitemap and robots routes for crawlability (static export compatible).
- Added SoftwareApplication JSON‑LD structured data.
- Added branded OG banner for social previews.

## Changes
- `app/layout.tsx`: metadata base, title template, canonical, OpenGraph/Twitter, keywords.
- `app/page.tsx`: SoftwareApplication JSON‑LD (publisher: Pillowbytes).
- `app/sitemap.ts`: sitemap route (force‑static).
- `app/robots.ts`: robots route with sitemap (force‑static).
- `public/og.svg`: OG image for share previews.

## Testing
- Not run (metadata/SEO changes only).
