### PR TITLE
fix(results): prevent scroll chaining in ResultsTable

### DIFF
--- a/components/ResultsTable.tsx
+++ b/components/ResultsTable.tsx
@@ -324,6 +324,9 @@ export default function ResultsTable({
     return () => window.removeEventListener('keydown', handler);
   }, [filtered, selectedRequestId, onSelectRequest]);
 
+  // When selection changes, keep the selected row centered in the table
+  // by adjusting the scrollTop of the internal container directly. This
+  // avoids using scrollIntoView which can cause the outer page to scroll.
   useEffect(() => {
     if (!selectedRequestId) return;
     const container = scrollRef.current;
@@ -332,7 +335,21 @@ export default function ResultsTable({
       `[data-request-id="${selectedRequestId}"]`
     ) as HTMLElement | null;
     if (!el) return;
-    el.scrollIntoView({ block: 'center' });
+
+    // Calculate an explicit scrollTop so only the inner container scrolls.
+    const elOffsetTop = el.offsetTop;
+    const elHeight = el.offsetHeight;
+    const targetScrollTop = Math.max(
+      0,
+      elOffsetTop - Math.round(container.clientHeight / 2) + Math.round(elHeight / 2)
+    );
+
+    // Smooth behavior feels nicer for keyboard navigation.
+    try {
+      container.scrollTo({ top: targetScrollTop, behavior: 'smooth' });
+    } catch (err) {
+      container.scrollTop = targetScrollTop;
+    }
   }, [selectedRequestId]);
 
   // Prevent scroll chaining from the results table to the page.
@@ -374,6 +391,45 @@ export default function ResultsTable({
       container.removeEventListener('touchmove', onTouchMove);
     };
   }, []);
+
+  // Handle keyboard navigation scoped to the results table container.
+  // Prevent default ArrowUp/ArrowDown page scrolling and keep focus inside the table.
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    // Make container focusable so it can receive keyboard events.
+    if (!(container as HTMLElement).hasAttribute('tabindex')) {
+      (container as HTMLElement).setAttribute('tabindex', '0');
+    }
+
+    const handler = (e: KeyboardEvent) => {
+      const active = document.activeElement;
+      if (!container.contains(active)) return;
+      if (!onSelectRequest || filtered.length === 0) return;
+
+      const idx = filtered.findIndex((r) => r.id === selectedRequestId);
+      if (idx === -1) return;
+
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        if (idx < filtered.length - 1) onSelectRequest(filtered[idx + 1].id);
+      }
+
+      if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        if (idx > 0) onSelectRequest(filtered[idx - 1].id);
+      }
+
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onSelectRequest(null);
+      }
+    };
+
+    container.addEventListener('keydown', handler);
+    return () => container.removeEventListener('keydown', handler);
+  }, [filtered, selectedRequestId, onSelectRequest]);
 
   if (!requests.length) return null;
 

--- a/components/ResultsTable.tsx
+++ b/components/ResultsTable.tsx
@@ -335,6 +335,46 @@ export default function ResultsTable({
     el.scrollIntoView({ block: 'center' });
   }, [selectedRequestId]);
 
+  // Prevent scroll chaining from the results table to the page.
+  // On wheel / touchmove, if the scroll container is at its bounds, stop propagation
+  // so the outer page does not scroll. This complements CSS overscroll-behavior
+  // for browsers that may still propagate touch/wheel events.
+  useEffect(() => {
+    const container = scrollRef.current;
+    if (!container) return;
+
+    const onWheel = (e: WheelEvent) => {
+      const delta = e.deltaY;
+      const atTop = container.scrollTop === 0;
+      const atBottom = Math.ceil(container.scrollTop + container.clientHeight) >= container.scrollHeight;
+
+      if ((atTop && delta < 0) || (atBottom && delta > 0)) {
+        e.preventDefault();
+        e.stopPropagation();
+      }
+    };
+
+    const onTouchMove = (e: TouchEvent) => {
+      const touch = e.touches[0];
+      if (!touch) return;
+      // We cannot determine direction easily without tracking start position;
+      // prevent default only when at bounds to avoid page scroll chaining.
+      const atTop = container.scrollTop === 0;
+      const atBottom = Math.ceil(container.scrollTop + container.clientHeight) >= container.scrollHeight;
+      if (atTop || atBottom) {
+        e.stopPropagation();
+      }
+    };
+
+    container.addEventListener('wheel', onWheel, { passive: false });
+    container.addEventListener('touchmove', onTouchMove, { passive: false });
+
+    return () => {
+      container.removeEventListener('wheel', onWheel);
+      container.removeEventListener('touchmove', onTouchMove);
+    };
+  }, []);
+
   if (!requests.length) return null;
 
   return (


### PR DESCRIPTION
Closes #16

## Summary
Prevent scroll chaining from the ResultsTable to the page by intercepting wheel and touchmove events at the table's scroll container, and ensure keyboard navigation keeps selection centered without scrolling the outer page.

## Root cause
The outer page was still scrollable when analysis mode was active and the ResultsTable used element.scrollIntoView to center selection. scrollIntoView can cause the browser to adjust the nearest scrollable ancestor, which allowed the body/page to shift when the table reached its top or bottom. Additionally, keyboard events (ArrowUp/ArrowDown) were allowed to bubble, letting the browser perform default scrolling behavior.

## How I fixed it
1. Prevented scroll chaining: added wheel and touchmove handlers on the ResultsTable scroll container that stop propagation and preventDefault when the inner container is at its bounds.
2. Replaced scrollIntoView with an explicit scrollTop calculation on the inner container so only the ResultsTable scrolls when centering the selected row.
3. Scoped keyboard handling: made the ResultsTable container focusable and intercept ArrowUp/ArrowDown key events to change selection and prevent default page scrolling.
4. Kept the change minimal and reversible; it complements existing CSS overscroll behavior.

## What I changed
- Two commits on fix-results-table-mox:
  - fix(results): prevent scroll chaining in ResultsTable (initial approach)
  - fix(results): center selection without scrolling page + scoped keyboard handling (keyboard handling, focus, and explicit scrollTop)

## Testing (local)
1. git checkout -b fix-results-table-mox origin/fix-results-table-mox
2. npm ci && npm run dev
3. Open the app, upload a HAR, and enter analysis mode.
4. Focus the ResultsTable (click into it) and use ArrowDown/ArrowUp to navigate:
   - The selected row should remain visually centered while there is scrollable space.
   - The page header should remain fixed; the page body must not scroll.
5. At the bottom of the table, continuing ArrowDown should advance selection to the last rows without causing the page to reveal blank space.

Branch: fix-results-table-mox